### PR TITLE
✨ Feature: 활동 정보 관련 API

### DIFF
--- a/src/main/java/umc/product/web/domain/activityInfo/controller/ActivityInfoController.java
+++ b/src/main/java/umc/product/web/domain/activityInfo/controller/ActivityInfoController.java
@@ -1,0 +1,26 @@
+package umc.product.web.domain.activityInfo.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.product.web.domain.activityInfo.dto.ActivityInfoResponseDTO;
+import umc.product.web.domain.activityInfo.service.ActivityInfoQueryService;
+import umc.product.web.global.common.BaseResponse;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/activities")
+@Tag(name = "활동 API")
+public class ActivityInfoController {
+
+    private final ActivityInfoQueryService activityInfoQueryService;
+
+    @GetMapping("")
+    public BaseResponse<ActivityInfoResponseDTO.ActivityInfoDetailDTO> getActivityInfoDetail() {
+        return BaseResponse.onSuccess(activityInfoQueryService.getActivityInfoDetail());
+    }
+}

--- a/src/main/java/umc/product/web/domain/activityInfo/converter/ActivityInfoInfoConverter.java
+++ b/src/main/java/umc/product/web/domain/activityInfo/converter/ActivityInfoInfoConverter.java
@@ -1,0 +1,21 @@
+package umc.product.web.domain.activityInfo.converter;
+
+import umc.product.web.domain.activityInfo.dto.ActivityInfoResponseDTO;
+import umc.product.web.domain.activityInfo.entity.ActivityInfo;
+
+public class ActivityInfoInfoConverter {
+
+    public static ActivityInfoResponseDTO.ActivityInfoDetailDTO activityInfoDetailDTO(ActivityInfo activityInfo) {
+
+        return ActivityInfoResponseDTO.ActivityInfoDetailDTO.builder()
+                .activityInfoId(activityInfo.getId())
+                .generation(activityInfo.getGeneration())
+                .activityStartDate(activityInfo.getActivityStartDate())
+                .activityEndDate(activityInfo.getActivityEndDate())
+                .unionOTDate(activityInfo.getUnionOTDate())
+                .clubFee(activityInfo.getClubFee())
+                .projectFee(activityInfo.getProjectFee())
+                .projectPaybackFee(activityInfo.getProjectPaybackFee())
+                .build();
+    }
+}

--- a/src/main/java/umc/product/web/domain/activityInfo/dto/ActivityInfoResponseDTO.java
+++ b/src/main/java/umc/product/web/domain/activityInfo/dto/ActivityInfoResponseDTO.java
@@ -1,0 +1,26 @@
+package umc.product.web.domain.activityInfo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class ActivityInfoResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ActivityInfoDetailDTO {
+        private Long activityInfoId;
+        private Integer generation;
+        private LocalDate activityStartDate;
+        private LocalDate activityEndDate;
+        private LocalDate unionOTDate;
+        private Integer clubFee;
+        private Integer projectFee;
+        private Integer projectPaybackFee;
+    }
+}

--- a/src/main/java/umc/product/web/domain/activityInfo/entity/ActivityInfo.java
+++ b/src/main/java/umc/product/web/domain/activityInfo/entity/ActivityInfo.java
@@ -18,6 +18,9 @@ public class ActivityInfo extends BaseEntity {
     @Column(name = "activity_info_id")
     private Long id;
 
+    @Column(name = "generation")
+    private Integer generation;
+
     @Column(name = "activity_start_date")
     private LocalDate activityStartDate;
 
@@ -25,11 +28,14 @@ public class ActivityInfo extends BaseEntity {
     private LocalDate activityEndDate;
 
     @Column(name = "union_ot_date")
-    private LocalDate unionOtDate;
+    private LocalDate unionOTDate;
 
     @Column(name = "club_fee")
     private Integer clubFee;
 
     @Column(name = "project_fee")
     private Integer projectFee;
+
+    @Column(name = "project_payback_fee")
+    private Integer projectPaybackFee;
 }

--- a/src/main/java/umc/product/web/domain/activityInfo/repository/ActivityInfoRepository.java
+++ b/src/main/java/umc/product/web/domain/activityInfo/repository/ActivityInfoRepository.java
@@ -1,0 +1,11 @@
+package umc.product.web.domain.activityInfo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.product.web.domain.activityInfo.entity.ActivityInfo;
+
+import java.util.Optional;
+
+public interface ActivityInfoRepository extends JpaRepository<ActivityInfo, Long> {
+
+    Optional<ActivityInfo> findTopByOrderByGenerationDesc();
+}

--- a/src/main/java/umc/product/web/domain/activityInfo/service/ActivityInfoQueryService.java
+++ b/src/main/java/umc/product/web/domain/activityInfo/service/ActivityInfoQueryService.java
@@ -1,0 +1,8 @@
+package umc.product.web.domain.activityInfo.service;
+
+import umc.product.web.domain.activityInfo.dto.ActivityInfoResponseDTO;
+
+public interface ActivityInfoQueryService {
+
+    ActivityInfoResponseDTO.ActivityInfoDetailDTO getActivityInfoDetail();
+}

--- a/src/main/java/umc/product/web/domain/activityInfo/service/impl/ActivityInfoInfoQueryServiceImpl.java
+++ b/src/main/java/umc/product/web/domain/activityInfo/service/impl/ActivityInfoInfoQueryServiceImpl.java
@@ -1,0 +1,32 @@
+package umc.product.web.domain.activityInfo.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.product.web.domain.activityInfo.converter.ActivityInfoInfoConverter;
+import umc.product.web.domain.activityInfo.dto.ActivityInfoResponseDTO;
+import umc.product.web.domain.activityInfo.entity.ActivityInfo;
+import umc.product.web.domain.activityInfo.repository.ActivityInfoRepository;
+import umc.product.web.domain.activityInfo.service.ActivityInfoQueryService;
+import umc.product.web.global.error.code.handler.ActivityHandler;
+
+import static umc.product.web.global.error.code.status.ErrorStatus.ACTIVITY_INFO_NOT_FOUND;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ActivityInfoInfoQueryServiceImpl implements ActivityInfoQueryService {
+
+    private final ActivityInfoRepository activityInfoRepository;
+
+    @Override
+    public ActivityInfoResponseDTO.ActivityInfoDetailDTO getActivityInfoDetail() {
+
+        ActivityInfo activityInfo = activityInfoRepository.findTopByOrderByGenerationDesc()
+                .orElseThrow(() -> new ActivityHandler(ACTIVITY_INFO_NOT_FOUND));
+
+        return ActivityInfoInfoConverter.activityInfoDetailDTO(activityInfo);
+    }
+}

--- a/src/main/java/umc/product/web/global/error/code/handler/ActivityHandler.java
+++ b/src/main/java/umc/product/web/global/error/code/handler/ActivityHandler.java
@@ -1,0 +1,10 @@
+package umc.product.web.global.error.code.handler;
+
+import umc.product.web.global.error.GeneralException;
+import umc.product.web.global.error.code.BaseErrorCode;
+
+public class ActivityHandler extends GeneralException {
+    public ActivityHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/umc/product/web/global/error/code/status/ErrorStatus.java
+++ b/src/main/java/umc/product/web/global/error/code/status/ErrorStatus.java
@@ -27,7 +27,10 @@ public enum ErrorStatus implements BaseErrorCode {
     SPONSOR_NOT_FOUND(HttpStatus.NOT_FOUND, "SPONSOR001", "SPONSOR가 존재하지 않습니다."),
 
     // Project 에러
-    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT001", "PROJECT가 존재하지 않습니다.");
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "PROJECT_001", "PROJECT가 존재하지 않습니다."),
+
+    // Activity Info 에러
+    ACTIVITY_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "ACTIVITY_INFO_001", "ACTIVITY INFO가 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
# 💡 PR Summary - 활동 정보 관련 API 구현
<!-- 어떤 작업에 대한 PR 인지 위 주석에 적어주세요 -->

### 📝 Description

---
<!-- 어떤 작업을 했는지 간단하게 적어주세요 -->
활동 정보 관련 API를 구현했습니다
- ActivityInfo 엔티티에 projectPaybackFee 필드 추가
- 기수별 활동 정보를 저장하고, 최신 기수의 활동 정보를 조회하도록 구현하기 위해서 ActivityInfo 엔티티에 generation 필드 추가

### 🌲 Working Branch

---
<!-- 예시) feature/user -->
feature/#5

### 📖 Related Issues

---
<!-- 예시) #1 -->
#5 


### 📚 Etc

---
<!-- 작업 중 특이사항이 생기면 적어주세요 -->
